### PR TITLE
Fix issue where #include in .h files are ignored

### DIFF
--- a/ekko.rb
+++ b/ekko.rb
@@ -9,17 +9,21 @@ def get_sources(filepath)
   content = File.read(filepath, mode: 'r')
   headers = content.scan(/^#include\ \"(.*?)\"/m).map { |header| header[0] }
   file_dir = File.dirname(filepath)
-  headers.map do |header|
+  result = headers.map do |header|
     source = File.path("#{file_dir}/#{header.gsub(/.h$/, '.cpp')}")
     raise "File #{source} does not exist" unless File.exist? source
 
     source
   end.to_set
+  result + headers.map do |header|
+    File.path "#{file_dir}/#{header}"
+  end
 end
 
 # run takes in an array of filepaths(to source files), compiles, runs, and
 # deletes the executables and the temp directories
 def run(files)
+  files = files.reject { |file| file.end_with? '.h' }
   filenames = files.map { |file| File.basename(file) }
   puts "Compiling #{filenames * ' '}..."
   Dir.mktmpdir('rucppy') do |dir|
@@ -44,6 +48,7 @@ while (filepath = queue.pop) && !filepath.nil?
   next if lookup.include? filepath
 
   lookup.add filepath
+  puts filepath
   get_sources(filepath).each { |filename| queue << filename }
 end
 


### PR DESCRIPTION
This issue fixes #2. Now the parser checks `.h` files for `#include ""` statements. 